### PR TITLE
Add test for UTF-8 characters in grammar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ python:
   - "3.6"
   - "pypy"  # PyPy2 2.5.0
   - "pypy3" # Pypy3 2.4.0
-script: python -m tests
+script:
+  - pip install -r nearley-requirements.txt
+  - python -m tests

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -55,17 +55,17 @@ class TestParsers(unittest.TestCase):
         self.assertRaises(ParseError, l.parse, 'a')
 
     def test_utf8(self):
-        g = """start: a
+        g = u"""start: a
                a: "±a"
             """
         l = Lark(g)
-        l.parse('±a')
+        l.parse(u'±a')
 
         l = Lark(g, parser='earley', lexer=None)
-        l.parse('±a')
+        l.parse(u'±a')
 
         l = Lark(g, parser='earley', lexer='dynamic')
-        l.parse('±a')
+        l.parse(u'±a')
 
 
 def _make_full_earley_test(LEXER):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import unittest
@@ -52,6 +53,19 @@ class TestParsers(unittest.TestCase):
 
         l = Lark(g, parser='earley', lexer='dynamic')
         self.assertRaises(ParseError, l.parse, 'a')
+
+    def test_utf8(self):
+        g = """start: a
+               a: "±a"
+            """
+        l = Lark(g)
+        l.parse('±a')
+
+        l = Lark(g, parser='earley', lexer=None)
+        l.parse('±a')
+
+        l = Lark(g, parser='earley', lexer='dynamic')
+        l.parse('±a')
 
 
 def _make_full_earley_test(LEXER):


### PR DESCRIPTION
For python3 it seems ok. It currently fails on python2 with:

```
Traceback (most recent call last):
  File "tests/test_parser.py", line 61, in test_utf8
    l = Lark(g)
  File "lark/lark.py", line 151, in __init__
    self.grammar = load_grammar(grammar, source)
  File "lark/load_grammar.py", line 538, in load_grammar
    tree = self.canonize_tree.transform( self.parser.parse(grammar_text+'\n') )
  File "lark/parser_frontends.py", line 31, in parse
    return self.parser.parse(tokens)
  File "lark/parsers/lalr_parser.py", line 67, in parse
    token = next(stream)
  File "lark/lexer.py", line 159, in lex
    t = Token(type_, value, lex_pos, line, lex_pos - col_start_pos)
  File "lark/lexer.py", line 24, in __new__
    inst = Str.__new__(cls, value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1: ordinal not in range(128)
```

I am looking into it but if you can see an obvious fix let me know.