### PR TITLE
Fixed TypeError on pretty-printing tuples in tree

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -21,14 +21,14 @@ class Tree(object):
 
     def _pretty(self, level, indent_str):
         if len(self.children) == 1 and not isinstance(self.children[0], Tree):
-            return [ indent_str*level, self._pretty_label(), '\t', '%s' % self.children[0], '\n']
+            return [ indent_str*level, self._pretty_label(), '\t', '%s' % (self.children[0],), '\n']
 
         l = [ indent_str*level, self._pretty_label(), '\n' ]
         for n in self.children:
             if isinstance(n, Tree):
                 l += n._pretty(level+1, indent_str)
             else:
-                l += [ indent_str*(level+1), '%s' % n, '\n' ]
+                l += [ indent_str*(level+1), '%s' % (n,), '\n' ]
 
         return l
 


### PR DESCRIPTION
When a tuple is passed as the argument to percent-formatting, its
elements are interpreted as multiple arguments. The pretty printer
previously passed tuples (e.g. those introduced via a Transformer) from
the tree directly to the percent operator, causing a TypeError because
the format string only calls for a single argument. This fix simply
wraps the argument in a one-tuple to ensure it is not interpreted as
multiple arguments if it itself is a tuple.