### PR TITLE
Propagated positions are wiped out by Transformers

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -116,12 +116,13 @@ class Transformer(object):
         try:
             f = self._get_func(tree.data)
         except AttributeError:
-            return self.__default__(tree.data, items)
+            if hasattr(self, '__default__'):
+                return self.__default__(tree.data, items)
+            else:
+                tree.set(tree.data, items)
+                return tree
         else:
             return f(items)
-
-    def __default__(self, data, children):
-        return Tree(data, children)
 
     def __mul__(self, other):
         return TransformerChain(self, other)


### PR DESCRIPTION
The mechanism of calling the __default__ method on the Transformer recreates tree items, wiping out any line and column numbers if you have propagated_positions on. This only calls the __default__ method if it exists; otherwise it fixes the tree in place (preserving properties).
