### PR TITLE
Allow functools partials to be used with the InlineTransformer

### DIFF
--- a/lark/utils.py
+++ b/lark/utils.py
@@ -71,6 +71,12 @@ def inline_args(f):
         def _f(self, args):
             return f.__func__(self, *args)
         return _f
+    elif isinstance(f, functools.partial):
+        # wraps does not work for partials in 2.7: https://bugs.python.org/issue3445
+        # @functools.wraps(f)
+        def _f(self, args):
+            return f(*args)
+        return _f
     else:
         @functools.wraps(f.__call__.__func__)
         def _f(self, args):


### PR DESCRIPTION
This allows you to do:
```
import functools

class MyTransformer(InlineTransformer):
    hexnumber = functools.partial(int, base=16)
    integer = functools.partial(int, base=10)
```
etc.