### PR TITLE
huge memory optimizations

### DIFF
--- a/lark/common.py
+++ b/lark/common.py
@@ -53,6 +53,7 @@ class ParserConf:
         self.rules = rules
         self.callback = callback
         self.start = start
+        self.parsetable_class = None
 
 
 

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -13,6 +13,7 @@ from .lexer import Lexer
 from .parse_tree_builder import ParseTreeBuilder
 from .parser_frontends import get_frontend
 
+
 class LarkOptions(object):
     """Specifies the options for Lark
 
@@ -41,6 +42,7 @@ class LarkOptions(object):
         profile - Measure run-time usage in Lark. Read results from the profiler proprety (Default: False)
         propagate_positions - Propagates [line, column, end_line, end_column] attributes into all tree branches.
         lexer_callbacks - Dictionary of callbacks for the lexer. May alter tokens during lexing. Use with caution.
+        parsetable_class - Use a specific parse table (only with parser="lalr")
     """
     __doc__ += OPTIONS_DOC
     def __init__(self, options_dict):
@@ -60,6 +62,7 @@ class LarkOptions(object):
         self.propagate_positions = o.pop('propagate_positions', False)
         self.earley__predict_all = o.pop('earley__predict_all', False)
         self.lexer_callbacks = o.pop('lexer_callbacks', {})
+        self.parsetable_class = o.pop('parsetable_class', None)
 
         assert self.parser in ('earley', 'lalr', 'cyk', None)
 
@@ -180,7 +183,6 @@ class Lark:
                     setattr(callback, f, self.profiler.make_wrapper('transformer', getattr(callback, f)))
 
         parser_conf = ParserConf(self.rules, callback, self.options.start)
-
         return self.parser_class(self.lexer_conf, parser_conf, options=self.options)
 
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -25,6 +25,8 @@ class UnexpectedInput(LexError):
         self.considered_rules = considered_rules
 
 class Token(Str):
+    __slots__ = ('type', 'pos_in_stream', 'value', 'line', 'column', 'end_line', 'end_column')
+
     def __new__(cls, type_, value, pos_in_stream=None, line=None, column=None):
         self = super(Token, cls).__new__(cls, value)
         self.type = type_
@@ -33,6 +35,26 @@ class Token(Str):
         self.line = line
         self.column = column
         return self
+
+    def __getstate__(self):
+        return {
+            'type': self.type,
+            'pos_in_stream': self.pos_in_stream,
+            'value': self.value,
+            'line': self.line,
+            'column': self.column,
+            'end_line': self.end_line,
+            'end_column': self.end_column
+        }
+
+    def __setstate__(self, state):
+        self.type = state['type']
+        self.pos_in_stream = state['pos_in_stream']
+        self.value = state['value']
+        self.line = state['line']
+        self.column = state['column']
+        self.end_line = state['end_line']
+        self.end_column = state['end_column']
 
     @classmethod
     def new_borrow_pos(cls, type_, value, borrow_t):

--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -39,14 +39,14 @@ class PropagatePositions:
         if children:
             for a in children:
                 with suppress(AttributeError):
-                    res.line = a.line
-                    res.column = a.column
+                    res['line'] = a.line
+                    res['column'] = a.column
                 break
 
             for a in reversed(children):
                 with suppress(AttributeError):
-                    res.end_line = a.end_line
-                    res.end_column = a.end_column
+                    res['end_line'] = a.end_line
+                    res['end_column'] = a.end_column
                 break
 
         return res
@@ -121,9 +121,8 @@ class ParseTreeBuilder:
             internal_callback_name = '_callback_%s_%s' % (rule.origin, '_'.join(rule.expansion))
 
             user_callback_name = rule.alias or rule.origin
-            try:
-                f = transformer._get_func(user_callback_name)
-            except AttributeError:
+            f = transformer._get_func(user_callback_name) if transformer else None
+            if f is None:
                 f = partial(self.tree_class, user_callback_name)
 
             self.user_aliases[rule] = rule.alias

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -15,9 +15,9 @@ class WithLexer:
 
     def init_contextual_lexer(self, lexer_conf, parser_conf):
         self.lexer_conf = lexer_conf
-        d = {idx:t.keys() for idx, t in self.parser.analysis.parse_table.states.items()}
+        state_map = {idx:list(t.keys()) for idx, t in self.parser.parse_table.states.items()}
         always_accept = lexer_conf.postlex.always_accept if lexer_conf.postlex else ()
-        self.lexer = ContextualLexer(lexer_conf.tokens, d, ignore=lexer_conf.ignore, always_accept=always_accept, user_callbacks=lexer_conf.callbacks)
+        self.lexer = ContextualLexer(lexer_conf.tokens, state_map, ignore=lexer_conf.ignore, always_accept=always_accept, user_callbacks=lexer_conf.callbacks)
 
     def lex(self, text):
         stream = self.lexer.lex(text)
@@ -29,6 +29,9 @@ class WithLexer:
 
 class LALR(WithLexer):
     def __init__(self, lexer_conf, parser_conf, options=None):
+        if options:
+            parser_conf.parsetable_class = options.parsetable_class
+
         self.parser = lalr_parser.Parser(parser_conf)
         self.init_traditional_lexer(lexer_conf)
 
@@ -39,6 +42,9 @@ class LALR(WithLexer):
 
 class LALR_ContextualLexer(WithLexer):
     def __init__(self, lexer_conf, parser_conf, options=None):
+        if options:
+            parser_conf.parsetable_class = options.parsetable_class
+
         self.parser = lalr_parser.Parser(parser_conf)
         self.init_contextual_lexer(lexer_conf, parser_conf)
 
@@ -165,8 +171,8 @@ class CYK(WithLexer):
 
     def _apply_callback(self, tree):
         children = tree.children
-        callback = self._postprocess[tree.rule.alias]
-        assert callback, tree.rule.alias
+        callback = self._postprocess[tree['rule'].alias]
+        assert callback, tree['rule'].alias
         r = callback(children)
         return r
 

--- a/lark/parsers/cyk.py
+++ b/lark/parsers/cyk.py
@@ -145,8 +145,7 @@ class Parser(object):
             else:
                 assert isinstance(child.s, Token)
                 children.append(child.s)
-        t = Tree(orig_rule.origin, children)
-        t.rule=orig_rule
+        t = Tree(orig_rule.origin, children, {'rule': orig_rule})
         return t
 
 

--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -21,12 +21,12 @@ from .grammar_analysis import GrammarAnalyzer
 class Derivation(Tree):
     _hash = None
 
-    def __init__(self, rule, items=None):
-        Tree.__init__(self, 'drv', items or [])
-        self.rule = rule
+    def __init__(self, rule, items=None, tags=None):
+        Tree.__init__(self, 'drv', items or [], tags)
+        self['rule'] = rule
 
     def _pretty_label(self):    # Nicer pretty for debugging the parser
-        return self.rule.origin if self.rule else self.data
+        return self['rule'].origin if self['rule'] else self.data
 
     def __hash__(self):
         if self._hash is None:
@@ -113,9 +113,8 @@ class Column:
 
                     if old_tree.data != '_ambig':
                         new_tree = old_tree.copy()
-                        new_tree.rule = old_tree.rule
                         old_tree.set('_ambig', [new_tree])
-                        old_tree.rule = None    # No longer a 'drv' node
+                        old_tree['rule'] = None    # No longer a 'drv' node
 
                     if item.tree.children[0] is old_tree:   # XXX a little hacky!
                         raise ParseError("Infinite recursion in grammar! (Rule %s)" % item.rule)
@@ -234,4 +233,4 @@ class ApplyCallbacks(Transformer_NoRecurse):
         self.postprocess = postprocess
 
     def drv(self, tree):
-        return self.postprocess[tree.rule](tree.children)
+        return self.postprocess[tree['rule']](tree.children)

--- a/lark/parsers/grammar_analysis.py
+++ b/lark/parsers/grammar_analysis.py
@@ -3,8 +3,12 @@ from ..utils import bfs, fzset, classify
 from ..common import GrammarError, is_terminal
 from ..grammar import Rule
 
+import weakref
+
 
 class RulePtr(object):
+    __slots__ = ('rule', 'index', 'next')
+
     def __init__(self, rule, index):
         assert isinstance(rule, Rule)
         assert index <= len(rule.expansion)
@@ -105,6 +109,7 @@ def calculate_sets(rules):
 class GrammarAnalyzer(object):
     def __init__(self, parser_conf, debug=False):
         self.debug = debug
+        self.parser_conf = parser_conf
 
         rules = parser_conf.rules + [Rule('$root', [parser_conf.start, '$END'])]
         self.rules_by_origin = classify(rules, lambda r: r.origin)
@@ -134,7 +139,8 @@ class GrammarAnalyzer(object):
                     if not is_terminal(new_r):
                         yield new_r
 
-        _ = list(bfs([rule], _expand_rule))
+        for _ in bfs([rule], _expand_rule):
+            pass
 
         return fzset(init_ptrs)
 

--- a/lark/parsers/grammar_analysis.py
+++ b/lark/parsers/grammar_analysis.py
@@ -5,7 +5,7 @@ from ..grammar import Rule
 
 
 class RulePtr(object):
-    __slots__ = ('rule', 'index', 'next')
+    __slots__ = ('rule', 'index')
 
     def __init__(self, rule, index):
         assert isinstance(rule, Rule)

--- a/lark/parsers/grammar_analysis.py
+++ b/lark/parsers/grammar_analysis.py
@@ -3,8 +3,6 @@ from ..utils import bfs, fzset, classify
 from ..common import GrammarError, is_terminal
 from ..grammar import Rule
 
-import weakref
-
 
 class RulePtr(object):
     __slots__ = ('rule', 'index', 'next')

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -8,6 +8,7 @@ For now, shift/reduce conflicts are automatically resolved as shifts.
 
 import logging
 from collections import defaultdict
+from array import array
 
 from ..utils import classify, classify_bool, bfs, fzset
 from ..common import GrammarError, is_terminal
@@ -31,6 +32,128 @@ class ParseTable:
         self.start_state = start_state
         self.end_state = end_state
 
+
+class ArrayParseTable(ParseTable):
+    """
+    Stores the parse table in a array of 16bit ints with all the states
+    packed one after the other in the following structure:
+
+        num_tokens [ token_id atom ]*
+
+    The atom has its highest bit set if it's a reduce action.
+    """
+
+    class StateProxy(object):
+        __slots__ = ('context', 'offset', 'cache')
+
+        def __init__(self, context, offset):
+            self.context = context
+            self.offset = offset
+            self.cache = {}
+
+        def keys(self):
+            ofs = self.offset
+            table = self.context.table
+            inv_tokens = {v:k for k,v in self.context.tokens.items()}
+            length = table[ofs]
+            ofs += 1
+            while length > 0:
+                yield inv_tokens[ table[ofs] ]
+                ofs += 2
+                length -= 1
+
+        def values(self):
+            for token in self.keys():
+                yield self[token]
+
+        def items(self):
+            for token in self.keys():
+                yield (token, self[token])
+
+        def __getitem__(self, token):
+            if token in self.cache:
+                return self.cache[token]
+
+            token_idx = self.context.tokens[token]
+            table = self.context.table
+            ofs = self.offset
+
+            # tokens are sorted so use a binary search to find it
+            lo = 0
+            hi = table[ofs]
+            ofs += 1
+            while lo < hi:
+                mid = (lo+hi)//2
+                value = table[ofs + mid*2]
+                if value < token_idx:
+                    lo = mid + 1
+                elif value > token_idx:
+                    hi = mid
+                else:
+                    self.cache[token] = self._unpack(table[ofs + mid*2 + 1])
+                    return self.cache[token]
+            else:
+                raise KeyError(token)
+
+        def _unpack(self, atom):
+            if atom & 0x8000:
+                atom &= ~0x8000
+                return Reduce, self.context.idx_rules[atom]
+            else:
+                return Shift, atom
+
+
+
+    def __init__(self, states, start_state, end_state):
+        states_idx = dict( (s, i) for i,s in enumerate(states.keys()) )
+
+        self.start_state = states_idx[start_state]
+        self.end_state = states_idx[end_state]
+
+        self.table = table = array('H')  # unsigned 16bit ints
+
+        self.tokens = tokens = {}
+        idx_tokens = []
+        rules = {}
+        self.idx_rules = idx_rules = []
+
+        self.states = {}
+        for state, productions in states.items():
+            # Create state proxy for the current offset
+            self.states[ states_idx[state] ] = ArrayParseTable.StateProxy(self, len(table))
+
+            # Prefix with the length of the state
+            table.append(len(productions))
+
+            # Sort the tokens based on the assigned index, indexing those
+            # that we haven't seen before
+            subtokens = []
+            for token in productions:
+                if token not in tokens:
+                    tokens[token] = len(idx_tokens)
+                    idx_tokens.append(token)
+
+                subtokens.append(tokens[token])
+
+            subtokens.sort()
+
+            for token_idx in subtokens:
+                token = idx_tokens[token_idx]
+                value = productions[token]
+
+                table.append(token_idx)
+
+                if value[0] is Shift:
+                    table.append(states_idx[ value[1] ])
+                else:
+                    if value[1] not in rules:
+                        rules[ value[1] ] = len(idx_rules)
+                        idx_rules.append(value[1])
+
+                    ptr = rules[ value[1] ] | 0x8000
+                    table.append(ptr)
+
+
 class IntParseTable(ParseTable):
 
     @classmethod
@@ -44,12 +167,9 @@ class IntParseTable(ParseTable):
                   for k,v in la.items()}
             int_states[ state_to_idx[s] ] = la
 
-
         start_state = state_to_idx[parse_table.start_state]
         end_state = state_to_idx[parse_table.end_state]
         return cls(int_states, start_state, end_state)
-
-
 
 
 class LALR_Analyzer(GrammarAnalyzer):
@@ -104,6 +224,7 @@ class LALR_Analyzer(GrammarAnalyzer):
 
         if self.debug:
             self.parse_table = self._parse_table
+        elif self.parser_conf.parsetable_class:
+            self.parse_table = self.parser_conf.parsetable_class(self.states, self.start_state, self.end_state)
         else:
             self.parse_table = IntParseTable.from_ParseTable(self._parse_table)
-

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -105,10 +105,11 @@ class ArrayParseTable(ParseTable):
 
 
     def __init__(self, states, start_state, end_state):
-        states_idx = dict( (s, i) for i,s in enumerate(states.keys()) )
+        idx_states = dict( (s, i) for i,s in enumerate(states.keys()) )
+        assert len(idx_states) < 0x8000, 'ArrayParseTable doesn\'t support more than 32767 states'
 
-        self.start_state = states_idx[start_state]
-        self.end_state = states_idx[end_state]
+        self.start_state = idx_states[start_state]
+        self.end_state = idx_states[end_state]
 
         self.table = table = array('H')  # unsigned 16bit ints
 
@@ -120,7 +121,7 @@ class ArrayParseTable(ParseTable):
         self.states = {}
         for state, productions in states.items():
             # Create state proxy for the current offset
-            self.states[ states_idx[state] ] = ArrayParseTable.StateProxy(self, len(table))
+            self.states[ idx_states[state] ] = ArrayParseTable.StateProxy(self, len(table))
 
             # Prefix with the length of the state
             table.append(len(productions))
@@ -132,6 +133,7 @@ class ArrayParseTable(ParseTable):
                 if token not in tokens:
                     tokens[token] = len(idx_tokens)
                     idx_tokens.append(token)
+                    assert len(idx_tokens) < 0x8000, 'ArrayParseTable doesn\'t support more than 32767 tokens'
 
                 subtokens.append(tokens[token])
 
@@ -144,11 +146,12 @@ class ArrayParseTable(ParseTable):
                 table.append(token_idx)
 
                 if value[0] is Shift:
-                    table.append(states_idx[ value[1] ])
+                    table.append(idx_states[ value[1] ])
                 else:
                     if value[1] not in rules:
                         rules[ value[1] ] = len(idx_rules)
                         idx_rules.append(value[1])
+                        assert len(idx_rules) < 0x8000, 'ArrayParseTable doesn\'t support more than 32767 rules'
 
                     ptr = rules[ value[1] ] | 0x8000
                     table.append(ptr)

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -92,8 +92,8 @@ class ArrayParseTable(ParseTable):
                 else:
                     self.cache[token] = self._unpack(table[ofs + mid*2 + 1])
                     return self.cache[token]
-            else:
-                raise KeyError(token)
+
+            raise KeyError(token)
 
         def _unpack(self, atom):
             if atom & 0x8000:

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -11,10 +11,14 @@ class Parser:
     def __init__(self, parser_conf):
         assert all(r.options is None or r.options.priority is None
                    for r in parser_conf.rules), "LALR doesn't yet support prioritization"
-        self.analysis = analysis = LALR_Analyzer(parser_conf)
+
+        analysis = LALR_Analyzer(parser_conf)
         analysis.compute_lookahead()
         callbacks = {rule: getattr(parser_conf.callback, rule.alias or rule.origin, None)
                           for rule in parser_conf.rules}
+
+        # Keeping the whole analysis around wastes tons of memory
+        self.parse_table = analysis.parse_table
 
         self.parser_conf = parser_conf
         self.parser = _Parser(analysis.parse_table, callbacks)

--- a/lark/parsers/resolve_ambig.py
+++ b/lark/parsers/resolve_ambig.py
@@ -20,7 +20,7 @@ def _sum_priority(tree):
 
     for n in tree.iter_subtrees():
         try:
-            p += n.rule.options.priority or 0
+            p += n['rule'].options.priority or 0
         except AttributeError:
             pass
 
@@ -49,7 +49,7 @@ def _compare_drv(tree1, tree2):
     if c:
         return c
 
-    c = _compare_rules(tree1.rule, tree2.rule)
+    c = _compare_rules(tree1['rule'], tree2['rule'])
     if c:
         return c
 
@@ -69,7 +69,7 @@ def _standard_resolve_ambig(tree):
     best = max(tree.children, key=key_f)
     assert best.data == 'drv'
     tree.set('drv', best.children)
-    tree.rule = best.rule   # needed for applying callbacks
+    tree['rule'] = best['rule']   # needed for applying callbacks
 
 def standard_resolve_ambig(tree):
     for ambig in tree.find_data('_ambig'):
@@ -97,7 +97,7 @@ def _antiscore_sum_resolve_ambig(tree):
     best = min(tree.children, key=_antiscore_sum_drv)
     assert best.data == 'drv'
     tree.set('drv', best.children)
-    tree.rule = best.rule   # needed for applying callbacks
+    tree['rule'] = best['rule']   # needed for applying callbacks
 
 def antiscore_sum_resolve_ambig(tree):
     for ambig in tree.find_data('_ambig'):

--- a/lark/parsers/resolve_ambig.py
+++ b/lark/parsers/resolve_ambig.py
@@ -29,9 +29,15 @@ def _sum_priority(tree):
 def _compare_priority(tree1, tree2):
     tree1.iter_subtrees()
 
+def _maybe_rule(tree):
+    try:
+        return tree['rule']
+    except Exception:
+        return None
+
 def _compare_drv(tree1, tree2):
-    rule1 = getattr(tree1, 'rule', None)
-    rule2 = getattr(tree2, 'rule', None)
+    rule1 = _maybe_rule(tree1)
+    rule2 = _maybe_rule(tree2)
 
     if None == rule1 == rule2:
         return compare(tree1, tree2)

--- a/lark/tools/nearley.py
+++ b/lark/tools/nearley.py
@@ -160,7 +160,7 @@ def create_code_for_nearley_grammar(g, start, builtin_path, folder_path):
     emit('class TransformNearley(Transformer):')
     for alias in n2l.alias_js_code:
         emit("    %s = var.get('%s').to_python()" % (alias, alias))
-    emit("    __default__ = lambda self, n, c: c if c else None")
+    emit("    __default__ = lambda self, n, c, *args: c if c else None")
 
     emit()
     emit('parser = Lark(grammar, start="n_%s")' % start)

--- a/lark/tools/standalone.py
+++ b/lark/tools/standalone.py
@@ -126,7 +126,7 @@ def _get_token_type(token_type):
 
 class ParserAtoms:
     def __init__(self, parser):
-        self.parse_table = parser.analysis.parse_table
+        self.parse_table = parser.parse_table
 
     def print_python(self):
         print('class ParseTable: pass')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -60,7 +60,7 @@ class TestParsers(unittest.TestCase):
                  """, propagate_positions=True)
 
         r = g.parse('a')
-        self.assertEqual( r.children[0].line, 1 )
+        self.assertEqual( r.children[0]['line'], 1 )
 
     def test_expand1(self):
 


### PR DESCRIPTION
First of all apologies for the big changeset, I'll comment on the PR to explain some parts better.

Here are some bench numbers:

### Baseline (master)

    test_python_lib (22 files), time: 0.936244010925 secs
    Partition of a set of 275823 objects. Total size = 46740096 bytes.
    Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
        0  99403  36 27832840  60  27832840  60 dict of lark.parsers.grammar_analysis.RulePtr
        1  99403  36  6361792  14  34194632  73 lark.parsers.grammar_analysis.RulePtr
        2   1685   1  2937080   6  37131712  79 dict (no owner)
        3  30415  11  2263704   5  39395416  84 tuple
        4   6514   2  1563360   3  40958776  88 lark.utils.fzset
        5  16075   6  1268840   3  42227616  90 str
        6    613   0   590968   1  42818584  92 dict of lark.lexer.Token
        7   2618   1   366672   1  43185256  92 list
        8    407   0   364304   1  43549560  93 type


### Optimizations

 - Speed: -13%
 - Memory: -565%
```
    test_python_lib (22 files), time: 0.826800107956 secs
    Partition of a set of 61184 objects. Total size = 8259976 bytes.
    Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
        0  23976  39  1801152  22   1801152  22 tuple
        1   1012   2  1667296  20   3468448  42 dict (no owner)
        2  16202  26  1278104  15   4746552  57 str
        3    408   1   365848   4   5112400  62 type
        4    112   0   347776   4   5460176  66 dict of module
        5   2470   4   345776   4   5805952  70 list
        6    408   1   337728   4   6143680  74 dict of type
        7   2314   4   296192   4   6439872  78 types.CodeType
        8   2099   3   251880   3   6691752  81 function
        9    169   0   154072   2   6845824  83 dict of class
```
### ArrayParseTable (no cache)

 - Speed: +56%
 - Memory: -739%
```
    test_python_lib (22 files), time: 1.65054392815 secs
    Partition of a set of 48642 objects. Total size = 6324520 bytes.
    Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
        0  16202  33  1278104  20   1278104  20 str
        1  10854  22   856384  14   2134488  34 tuple
        2    425   1   562904   9   2697392  43 dict (no owner)
        3    408   1   365848   6   3063240  48 type
        4   2471   5   348920   6   3412160  54 list
```
### ArrayParseTable (cached)

 - Speed: +5%
 - Memory: -669%
```
    test_python_lib (22 files), time: 0.975975990295 secs
    Partition of a set of 53713 objects. Total size = 6978824 bytes.
    Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
        0  16174  30  1276744  18   1276744  18 str
        1  14268  27  1102200  16   2378944  34 tuple
        2   1013   2   946424  14   3325368  48 dict (no owner)
        3    408   1   365848   5   3691216  53 type
        4   2471   5   348920   5   4040136  58 list
```