### PR TITLE
example driven parser errors

### DIFF
--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -2,7 +2,6 @@
 """
 # Author: Erez Shinan (2017)
 # Email : erezshin@gmail.com
-
 from ..common import UnexpectedToken
 
 from .lalr_analysis import LALR_Analyzer, Shift
@@ -47,8 +46,7 @@ class _Parser:
                 return states[state][key]
             except KeyError:
                 expected = states[state].keys()
-
-                raise UnexpectedToken(token, expected, seq, i)
+                raise UnexpectedToken(token, expected, seq, i, state=state)
 
         def reduce(rule):
             size = len(rule.expansion)


### PR DESCRIPTION
> Based on this paper [Generating LR Syntax Error Messages from Examples](http://people.via.ecp.fr/~stilgar/doc/compilo/parser/Generating%20LR%20Syntax%20Error%20Messages.pdf).

Implementing user friendly error reporting on a parser is not a especially simple task. While additional rules can be added to the grammar to catch common errors, they might interfere with the correct rules if we're not careful, moreover they grow the grammar and can make the parsing slower.

How this works is by crafting a set of malformed syntax examples, which upon an error can be provided to find the one that generates an equivalent parser state, hence we can override the generic error with a custom label.

This is an example usage for the JSON parser:

```py
    try:
        ast = parse(my_code)
    except UnexpectedToken as ut:
        label = ut.match_examples(parse, {
            'missing opening': ['{"foo": ]}', '{"foor": }}'],
            'missing closing': ['{"foo": [}', '{"foo": {'],
            'trailing comma': ['[,]', '[1,]', '[1,2,]' '{"foo":1,}', '{"foo":false,"bar":true,}']
        })

        if label:
            raise SyntaxError('{} at line {}, column {}.'.format(label, ut.line, ut.column))

        raise SyntaxError(str(ut))
```

Open points:

 - Not sure if this is genarizable to other parser types besides the LALR one
 - Undecided about where to put the `match_example` function, should it be a method of `UnexpectedError` or just a helper function in a module?